### PR TITLE
Add option to automatically rejoin previous party on startup

### DIFF
--- a/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
@@ -18,6 +18,16 @@ public interface PartyPanelConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "autoRejoinParty",
+		name = "Startup in previous party",
+		description = "<html>Controls whether we automatically join the previous party.</html>"
+	)
+	default boolean autoRejoinParty()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showPartyControls",
 		name = "Show Party Controls",
 		description = "<html>Controls whether we display the party control buttons like create and leave party</html>",

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
@@ -133,6 +133,11 @@ public class PartyPanelPlugin extends Plugin
 
 		wsClient.registerMessage(PartyBatchedChange.class);
 
+		if(!isInParty() && config.autoRejoinParty())
+		{
+			changeParty(config.previousPartyId());
+		}
+
 		if (isInParty() || config.alwaysShowIcon())
 		{
 			clientToolbar.addNavigation(navButton);


### PR DESCRIPTION
It annoyed me, that i always have to click the "Join previous party"-button on startup to see what my friends are doing so i added this "feature".

If there is anything i missed while doing these changes, just let me know I would be happy to adjust.