### PR TITLE
Add support for a predefined list of party names in the config

### DIFF
--- a/src/main/java/thestonedturtle/partypanel/PartyPanel.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanel.java
@@ -223,4 +223,8 @@ class PartyPanel extends PluginPanel
 	{
 		playerPanelMap.values().forEach(PlayerPanel::updateDisplayPlayerWorlds);
 	}
+
+	public void updatePredefinedPartyNames() {
+		controlsPanel.updateControls();
+	}
 }

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
@@ -92,4 +92,16 @@ public interface PartyPanelConfig extends Config
 		hidden = true
 	)
 	void setPreviousPartyId(String id);
+
+	@ConfigItem(
+		keyName = "predefinedPartyNames",
+		name = "Predefined Party Names",
+		description = "<html>Controls a comma-separated predefined list of party names.<br/>Each name will generate a button in the sidebar as a shortcut to join.",
+		position = 5
+	)
+	default String predefinedPartyNames()
+	{
+		return "";
+	}
+
 }

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
@@ -234,6 +234,9 @@ public class PartyPanelPlugin extends Plugin
 			case "displayPlayerWorlds":
 				panel.updateDisplayPlayerWorlds();
 				break;
+			case "predefinedPartyNames":
+				panel.updatePredefinedPartyNames();
+				break;
 		}
 	}
 


### PR DESCRIPTION
Add a config field for allowing the user to specify a list of party names. This is useful when a player needs to join on a bunch of accounts (alting), for players who join a different party based on who they're bossing with (eg., some friends are often in party x, others often in party y, etc.).

`ControlPanel#updateControls` has to to a bit extra shenanigans to handle updating the list of buttons; happy to move that to a helper function if preferred (or if any other changes). Also, there's some hardcoding about positioning with the `GridBagConstraints` (which was already there beforehand in the constructor, but is a bit more gross with the list logic now). Not sure if there's a better way, I'm not familiar with swing.

Screen recording from testing is too large to attach, so here's what I tested with this:

1. No buttons or header are shown when predefined party list config is empty (so for anyone who doesn't add names to the config option, there is no visual change to the sidebar)
2. Party buttons are updated when the config changes (new ones added and old ones deleted)
3. No extra buttons or header are shown when in a party
4. Trims whitespace before or after a comma-delimited entry. If there is a space within an entry, it's handled the same as a party with a space (gets converted to a hyphen). If it's a newline, it gets concatenated with no space (not really intentional but idk why there would be a newline in a party name)
    Very long party names just overflow and get cutoff in the sidebar; this is somewhere around 30 characters, so doesn't really seem like a problem to me (also not sure what the alternative would be).

