### PR TITLE
Feature/world hop button

### DIFF
--- a/src/main/java/thestonedturtle/partypanel/PartyPanel.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanel.java
@@ -166,7 +166,8 @@ class PartyPanel extends PluginPanel
 			return;
 		}
 
-		panel = new PlayerPanel(player, plugin.getConfig(), plugin.spriteManager, plugin.itemManager);
+		panel = new PlayerPanel(player, plugin.getConfig(), plugin::hopToPartyMemberWorld,
+			plugin.spriteManager, plugin.itemManager);
 		playerPanelMap.put(player.getMember().getMemberId(), panel);
 		panel.updatePlayerData(player, hasBreakingBannerChange);
 		basePanel.add(panel);
@@ -221,6 +222,6 @@ class PartyPanel extends PluginPanel
 
 	public void updateDisplayPlayerWorlds()
 	{
-		playerPanelMap.values().forEach(PlayerPanel::updateDisplayPlayerWorlds);
+		playerPanelMap.values().forEach(PlayerPanel::updateWorld);
 	}
 }

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
@@ -64,7 +64,7 @@ public interface PartyPanelConfig extends Config
 	@ConfigItem(
 			keyName = "displayPlayerWorlds",
 			name = "Display Player Worlds",
-			description = "<html>Controls whether we display the world a player is currently on<br/>Disabling this also hides the hop-to world button</html>",
+			description = "<html>Controls whether we display the world a player is currently on<br/>Disabling this also hides the hop-to world menu option</html>",
 			position = 4
 	)
 	default boolean displayPlayerWorlds()
@@ -73,12 +73,12 @@ public interface PartyPanelConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showHopToWorldButton",
-			name = "Show Hop-to World Button",
-			description = "<html>Controls whether a button is displayed to hop to a party member's current world<br/>Only applies when Display Player Worlds is enabled</html>",
+			keyName = "showHopToWorldMenuOption",
+			name = "Show Hop-to World Menu Option",
+			description = "<html>Controls whether a right-click option is displayed to hop to a party member's current world<br/>Only applies when Display Player Worlds is enabled</html>",
 			position = 5
 	)
-	default boolean showHopToWorldButton()
+	default boolean showHopToWorldMenuOption()
 	{
 		return false;
 	}

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelConfig.java
@@ -64,7 +64,7 @@ public interface PartyPanelConfig extends Config
 	@ConfigItem(
 			keyName = "displayPlayerWorlds",
 			name = "Display Player Worlds",
-			description = "<html>Controls whether we display the world a player is currently on</html>",
+			description = "<html>Controls whether we display the world a player is currently on<br/>Disabling this also hides the hop-to world button</html>",
 			position = 4
 	)
 	default boolean displayPlayerWorlds()
@@ -72,12 +72,22 @@ public interface PartyPanelConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+			keyName = "showHopToWorldButton",
+			name = "Show Hop-to World Button",
+			description = "<html>Controls whether a button is displayed to hop to a party member's current world<br/>Only applies when Display Player Worlds is enabled</html>",
+			position = 5
+	)
+	default boolean showHopToWorldButton()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 			keyName = "displayPartyReminderOverlay",
 			name = "Display Party Reminder",
 			description = "Displays an overlay when you are not in a party",
-			position = 5
+			position = 6
 	)
 	default boolean displayPartyReminderOverlay()
 	{

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
@@ -15,16 +16,22 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
 import net.runelite.api.annotations.Varbit;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -33,6 +40,7 @@ import net.runelite.client.events.PartyMemberAvatar;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.game.SpriteManager;
+import net.runelite.client.game.WorldService;
 import net.runelite.client.party.PartyService;
 import net.runelite.client.party.WSClient;
 import net.runelite.client.party.events.UserPart;
@@ -44,6 +52,10 @@ import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.WorldUtil;
+import net.runelite.http.api.worlds.World;
+import net.runelite.http.api.worlds.WorldResult;
+import net.runelite.http.api.worlds.WorldType;
 import org.apache.commons.lang3.ArrayUtils;
 import thestonedturtle.partypanel.data.GameItem;
 import thestonedturtle.partypanel.data.PartyPlayer;
@@ -78,6 +90,8 @@ import java.util.Set;
 public class PartyPanelPlugin extends Plugin
 {
 	private static final BufferedImage ICON = ImageUtil.loadImageResource(PartyPanelPlugin.class, "icon.png");
+	private static final int DISPLAY_SWITCHER_MAX_ATTEMPTS = 3;
+	private static final String WORLD_SWITCHER_BUSY_MESSAGE = "Please finish what you're doing before using the World Switcher.";
 	private static final int[] RUNEPOUCH_AMOUNT_VARBITS = {
 			VarbitID.RUNE_POUCH_QUANTITY_1, VarbitID.RUNE_POUCH_QUANTITY_2, VarbitID.RUNE_POUCH_QUANTITY_3,
 			VarbitID.RUNE_POUCH_QUANTITY_4, VarbitID.RUNE_POUCH_QUANTITY_5, VarbitID.RUNE_POUCH_QUANTITY_6,
@@ -128,6 +142,12 @@ public class PartyPanelPlugin extends Plugin
 	@Inject
 	private PartyReminderOverlay partyReminderOverlay;
 
+	@Inject
+	private WorldService worldService;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
 	@Provides
 	PartyPanelConfig provideConfig(ConfigManager configManager)
 	{
@@ -145,6 +165,8 @@ public class PartyPanelPlugin extends Plugin
 
 	private PartyPanel panel;
 	private Instant lastLogout;
+	private net.runelite.api.World quickHopTargetWorld;
+	private int displaySwitcherAttempts = 0;
 
 	// All events should be deferred to the next game tick
 	private PartyBatchedChange currentChange = new PartyBatchedChange();
@@ -201,6 +223,7 @@ public class PartyPanelPlugin extends Plugin
 		partyMembers.clear();
 		wsClient.unregisterMessage(PartyBatchedChange.class);
 		currentChange = new PartyBatchedChange();
+		resetQuickHop();
 		panel.getPlayerPanelMap().clear();
 		lastLogout = null;
 		overlayManager.remove(partyReminderOverlay);
@@ -244,6 +267,7 @@ public class PartyPanelPlugin extends Plugin
 				panel.updateDisplayVirtualLevels();
 				break;
 			case "displayPlayerWorlds":
+			case "showHopToWorldButton":
 				panel.updateDisplayPlayerWorlds();
 				break;
 		}
@@ -389,6 +413,11 @@ public class PartyPanelPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(final GameTick tick)
 	{
+		if (quickHopTargetWorld != null)
+		{
+			processQuickHop();
+		}
+
 		if (!isInParty() || client.getLocalPlayer() == null || partyService.getLocalMember() == null)
 		{
 			return;
@@ -503,6 +532,15 @@ public class PartyPanelPlugin extends Plugin
 			partyService.send(currentChange);
 
 			currentChange = new PartyBatchedChange();
+		}
+	}
+
+	@Subscribe
+	public void onChatMessage(final ChatMessage event)
+	{
+		if (event.getType() == ChatMessageType.GAMEMESSAGE && WORLD_SWITCHER_BUSY_MESSAGE.equals(event.getMessage()))
+		{
+			resetQuickHop();
 		}
 	}
 
@@ -826,6 +864,132 @@ public class PartyPanelPlugin extends Plugin
 	{
 		partyService.changeParty(null);
 		panel.updateParty();
+	}
+
+	public void hopToPartyMemberWorld(final int worldId)
+	{
+		clientThread.invoke(() -> hopToWorld(worldId));
+	}
+
+	private void hopToWorld(int worldId)
+	{
+		assert client.isClientThread();
+
+		if (worldId <= 0 || worldId == client.getWorld())
+		{
+			return;
+		}
+
+		final WorldResult worldResult = worldService.getWorlds();
+		if (worldResult == null)
+		{
+			worldService.refresh();
+			queueConsoleMessage("Unable to find world " + worldId + ". Refreshing world list.");
+			return;
+		}
+
+		final World currentWorld = worldResult.findWorld(client.getWorld());
+		final World targetWorld = worldResult.findWorld(worldId);
+		if (targetWorld == null)
+		{
+			queueConsoleMessage("Unknown world " + worldId + ".");
+			return;
+		}
+
+		if (currentWorld != null
+			&& !currentWorld.getTypes().contains(WorldType.PVP)
+			&& targetWorld.getTypes().contains(WorldType.PVP))
+		{
+			queueConsoleMessage("Use the World Switcher to hop to PvP worlds.");
+			return;
+		}
+
+		final net.runelite.api.World rsWorld = client.createWorld();
+		rsWorld.setActivity(targetWorld.getActivity());
+		rsWorld.setAddress(targetWorld.getAddress());
+		rsWorld.setId(targetWorld.getId());
+		rsWorld.setPlayerCount(targetWorld.getPlayers());
+		rsWorld.setLocation(targetWorld.getLocation());
+		rsWorld.setTypes(WorldUtil.toWorldTypes(targetWorld.getTypes()));
+
+		if (client.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			client.changeWorld(rsWorld);
+			return;
+		}
+
+		queueQuickHopMessage(targetWorld.getId());
+		quickHopTargetWorld = rsWorld;
+		displaySwitcherAttempts = 0;
+	}
+
+	private void processQuickHop()
+	{
+		assert client.isClientThread();
+
+		if (client.getWidget(InterfaceID.Worldswitcher.BUTTONS) == null)
+		{
+			client.openWorldHopper();
+
+			if (++displaySwitcherAttempts >= DISPLAY_SWITCHER_MAX_ATTEMPTS)
+			{
+				queueFailedQuickHopMessage();
+				resetQuickHop();
+			}
+
+			return;
+		}
+
+		client.hopToWorld(quickHopTargetWorld);
+		resetQuickHop();
+	}
+
+	private void resetQuickHop()
+	{
+		displaySwitcherAttempts = 0;
+		quickHopTargetWorld = null;
+	}
+
+	private void queueConsoleMessage(final String message)
+	{
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.value(message)
+			.build());
+	}
+
+	private void queueQuickHopMessage(final int worldId)
+	{
+		final String chatMessage = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append("Quick-hopping to World ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(Integer.toString(worldId))
+			.append(ChatColorType.NORMAL)
+			.append("..")
+			.build();
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.runeLiteFormattedMessage(chatMessage)
+			.build());
+	}
+
+	private void queueFailedQuickHopMessage()
+	{
+		final String chatMessage = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append("Failed to quick-hop after ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(Integer.toString(displaySwitcherAttempts))
+			.append(ChatColorType.NORMAL)
+			.append(" attempts.")
+			.build();
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.runeLiteFormattedMessage(chatMessage)
+			.build());
 	}
 
 	private int[] convertItemsToArray(Item[] items)

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
@@ -249,7 +249,7 @@ public class PartyPanelPlugin extends Plugin
 				panel.updateDisplayVirtualLevels();
 				break;
 			case "displayPlayerWorlds":
-			case "showHopToWorldButton":
+			case "showHopToWorldMenuOption":
 				panel.updateDisplayPlayerWorlds();
 				break;
 		}

--- a/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
+++ b/src/main/java/thestonedturtle/partypanel/PartyPanelPlugin.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
@@ -23,15 +22,10 @@ import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.InventoryID;
-import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.chat.ChatColorType;
-import net.runelite.client.chat.ChatMessageBuilder;
-import net.runelite.client.chat.ChatMessageManager;
-import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -40,7 +34,6 @@ import net.runelite.client.events.PartyMemberAvatar;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.game.SpriteManager;
-import net.runelite.client.game.WorldService;
 import net.runelite.client.party.PartyService;
 import net.runelite.client.party.WSClient;
 import net.runelite.client.party.events.UserPart;
@@ -52,10 +45,6 @@ import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
-import net.runelite.client.util.WorldUtil;
-import net.runelite.http.api.worlds.World;
-import net.runelite.http.api.worlds.WorldResult;
-import net.runelite.http.api.worlds.WorldType;
 import org.apache.commons.lang3.ArrayUtils;
 import thestonedturtle.partypanel.data.GameItem;
 import thestonedturtle.partypanel.data.PartyPlayer;
@@ -90,8 +79,6 @@ import java.util.Set;
 public class PartyPanelPlugin extends Plugin
 {
 	private static final BufferedImage ICON = ImageUtil.loadImageResource(PartyPanelPlugin.class, "icon.png");
-	private static final int DISPLAY_SWITCHER_MAX_ATTEMPTS = 3;
-	private static final String WORLD_SWITCHER_BUSY_MESSAGE = "Please finish what you're doing before using the World Switcher.";
 	private static final int[] RUNEPOUCH_AMOUNT_VARBITS = {
 			VarbitID.RUNE_POUCH_QUANTITY_1, VarbitID.RUNE_POUCH_QUANTITY_2, VarbitID.RUNE_POUCH_QUANTITY_3,
 			VarbitID.RUNE_POUCH_QUANTITY_4, VarbitID.RUNE_POUCH_QUANTITY_5, VarbitID.RUNE_POUCH_QUANTITY_6,
@@ -143,10 +130,7 @@ public class PartyPanelPlugin extends Plugin
 	private PartyReminderOverlay partyReminderOverlay;
 
 	@Inject
-	private WorldService worldService;
-
-	@Inject
-	private ChatMessageManager chatMessageManager;
+	private WorldHopService worldHopService;
 
 	@Provides
 	PartyPanelConfig provideConfig(ConfigManager configManager)
@@ -165,8 +149,6 @@ public class PartyPanelPlugin extends Plugin
 
 	private PartyPanel panel;
 	private Instant lastLogout;
-	private net.runelite.api.World quickHopTargetWorld;
-	private int displaySwitcherAttempts = 0;
 
 	// All events should be deferred to the next game tick
 	private PartyBatchedChange currentChange = new PartyBatchedChange();
@@ -223,7 +205,7 @@ public class PartyPanelPlugin extends Plugin
 		partyMembers.clear();
 		wsClient.unregisterMessage(PartyBatchedChange.class);
 		currentChange = new PartyBatchedChange();
-		resetQuickHop();
+		worldHopService.reset();
 		panel.getPlayerPanelMap().clear();
 		lastLogout = null;
 		overlayManager.remove(partyReminderOverlay);
@@ -413,10 +395,7 @@ public class PartyPanelPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(final GameTick tick)
 	{
-		if (quickHopTargetWorld != null)
-		{
-			processQuickHop();
-		}
+		worldHopService.processQuickHop();
 
 		if (!isInParty() || client.getLocalPlayer() == null || partyService.getLocalMember() == null)
 		{
@@ -538,10 +517,7 @@ public class PartyPanelPlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(final ChatMessage event)
 	{
-		if (event.getType() == ChatMessageType.GAMEMESSAGE && WORLD_SWITCHER_BUSY_MESSAGE.equals(event.getMessage()))
-		{
-			resetQuickHop();
-		}
+		worldHopService.onChatMessage(event);
 	}
 
 	@Subscribe
@@ -868,128 +844,7 @@ public class PartyPanelPlugin extends Plugin
 
 	public void hopToPartyMemberWorld(final int worldId)
 	{
-		clientThread.invoke(() -> hopToWorld(worldId));
-	}
-
-	private void hopToWorld(int worldId)
-	{
-		assert client.isClientThread();
-
-		if (worldId <= 0 || worldId == client.getWorld())
-		{
-			return;
-		}
-
-		final WorldResult worldResult = worldService.getWorlds();
-		if (worldResult == null)
-		{
-			worldService.refresh();
-			queueConsoleMessage("Unable to find world " + worldId + ". Refreshing world list.");
-			return;
-		}
-
-		final World currentWorld = worldResult.findWorld(client.getWorld());
-		final World targetWorld = worldResult.findWorld(worldId);
-		if (targetWorld == null)
-		{
-			queueConsoleMessage("Unknown world " + worldId + ".");
-			return;
-		}
-
-		if (currentWorld != null
-			&& !currentWorld.getTypes().contains(WorldType.PVP)
-			&& targetWorld.getTypes().contains(WorldType.PVP))
-		{
-			queueConsoleMessage("Use the World Switcher to hop to PvP worlds.");
-			return;
-		}
-
-		final net.runelite.api.World rsWorld = client.createWorld();
-		rsWorld.setActivity(targetWorld.getActivity());
-		rsWorld.setAddress(targetWorld.getAddress());
-		rsWorld.setId(targetWorld.getId());
-		rsWorld.setPlayerCount(targetWorld.getPlayers());
-		rsWorld.setLocation(targetWorld.getLocation());
-		rsWorld.setTypes(WorldUtil.toWorldTypes(targetWorld.getTypes()));
-
-		if (client.getGameState() == GameState.LOGIN_SCREEN)
-		{
-			client.changeWorld(rsWorld);
-			return;
-		}
-
-		queueQuickHopMessage(targetWorld.getId());
-		quickHopTargetWorld = rsWorld;
-		displaySwitcherAttempts = 0;
-	}
-
-	private void processQuickHop()
-	{
-		assert client.isClientThread();
-
-		if (client.getWidget(InterfaceID.Worldswitcher.BUTTONS) == null)
-		{
-			client.openWorldHopper();
-
-			if (++displaySwitcherAttempts >= DISPLAY_SWITCHER_MAX_ATTEMPTS)
-			{
-				queueFailedQuickHopMessage();
-				resetQuickHop();
-			}
-
-			return;
-		}
-
-		client.hopToWorld(quickHopTargetWorld);
-		resetQuickHop();
-	}
-
-	private void resetQuickHop()
-	{
-		displaySwitcherAttempts = 0;
-		quickHopTargetWorld = null;
-	}
-
-	private void queueConsoleMessage(final String message)
-	{
-		chatMessageManager.queue(QueuedMessage.builder()
-			.type(ChatMessageType.CONSOLE)
-			.value(message)
-			.build());
-	}
-
-	private void queueQuickHopMessage(final int worldId)
-	{
-		final String chatMessage = new ChatMessageBuilder()
-			.append(ChatColorType.NORMAL)
-			.append("Quick-hopping to World ")
-			.append(ChatColorType.HIGHLIGHT)
-			.append(Integer.toString(worldId))
-			.append(ChatColorType.NORMAL)
-			.append("..")
-			.build();
-
-		chatMessageManager.queue(QueuedMessage.builder()
-			.type(ChatMessageType.CONSOLE)
-			.runeLiteFormattedMessage(chatMessage)
-			.build());
-	}
-
-	private void queueFailedQuickHopMessage()
-	{
-		final String chatMessage = new ChatMessageBuilder()
-			.append(ChatColorType.NORMAL)
-			.append("Failed to quick-hop after ")
-			.append(ChatColorType.HIGHLIGHT)
-			.append(Integer.toString(displaySwitcherAttempts))
-			.append(ChatColorType.NORMAL)
-			.append(" attempts.")
-			.build();
-
-		chatMessageManager.queue(QueuedMessage.builder()
-			.type(ChatMessageType.CONSOLE)
-			.runeLiteFormattedMessage(chatMessage)
-			.build());
+		worldHopService.hopToWorld(worldId);
 	}
 
 	private int[] convertItemsToArray(Item[] items)

--- a/src/main/java/thestonedturtle/partypanel/WorldHopService.java
+++ b/src/main/java/thestonedturtle/partypanel/WorldHopService.java
@@ -1,0 +1,185 @@
+package thestonedturtle.partypanel;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.client.game.WorldService;
+import net.runelite.client.util.WorldUtil;
+import net.runelite.http.api.worlds.World;
+import net.runelite.http.api.worlds.WorldResult;
+import net.runelite.http.api.worlds.WorldType;
+
+@Singleton
+class WorldHopService
+{
+	private static final int DISPLAY_SWITCHER_MAX_ATTEMPTS = 3;
+	private static final String WORLD_SWITCHER_BUSY_MESSAGE = "Please finish what you're doing before using the World Switcher.";
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
+
+	@Inject
+	private WorldService worldService;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	private net.runelite.api.World quickHopTargetWorld;
+	private int displaySwitcherAttempts = 0;
+
+	void hopToWorld(final int worldId)
+	{
+		clientThread.invoke(() -> hop(worldId));
+	}
+
+	void processQuickHop()
+	{
+		assert client.isClientThread();
+
+		if (quickHopTargetWorld == null)
+		{
+			return;
+		}
+
+		if (client.getWidget(InterfaceID.Worldswitcher.BUTTONS) == null)
+		{
+			client.openWorldHopper();
+
+			if (++displaySwitcherAttempts >= DISPLAY_SWITCHER_MAX_ATTEMPTS)
+			{
+				queueFailedQuickHopMessage();
+				resetQuickHop();
+			}
+
+			return;
+		}
+
+		client.hopToWorld(quickHopTargetWorld);
+		resetQuickHop();
+	}
+
+	void onChatMessage(final ChatMessage event)
+	{
+		if (event.getType() == ChatMessageType.GAMEMESSAGE && WORLD_SWITCHER_BUSY_MESSAGE.equals(event.getMessage()))
+		{
+			resetQuickHop();
+		}
+	}
+
+	void reset()
+	{
+		resetQuickHop();
+	}
+
+	private void hop(final int worldId)
+	{
+		assert client.isClientThread();
+
+		if (worldId <= 0 || worldId == client.getWorld())
+		{
+			return;
+		}
+
+		final WorldResult worldResult = worldService.getWorlds();
+		if (worldResult == null)
+		{
+			worldService.refresh();
+			queueConsoleMessage("Unable to find world " + worldId + ". Refreshing world list.");
+			return;
+		}
+
+		final World currentWorld = worldResult.findWorld(client.getWorld());
+		final World targetWorld = worldResult.findWorld(worldId);
+		if (targetWorld == null)
+		{
+			queueConsoleMessage("Unknown world " + worldId + ".");
+			return;
+		}
+
+		if (currentWorld != null
+			&& !currentWorld.getTypes().contains(WorldType.PVP)
+			&& targetWorld.getTypes().contains(WorldType.PVP))
+		{
+			queueConsoleMessage("Use the World Switcher to hop to PvP worlds.");
+			return;
+		}
+
+		final net.runelite.api.World rsWorld = client.createWorld();
+		rsWorld.setActivity(targetWorld.getActivity());
+		rsWorld.setAddress(targetWorld.getAddress());
+		rsWorld.setId(targetWorld.getId());
+		rsWorld.setPlayerCount(targetWorld.getPlayers());
+		rsWorld.setLocation(targetWorld.getLocation());
+		rsWorld.setTypes(WorldUtil.toWorldTypes(targetWorld.getTypes()));
+
+		if (client.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			client.changeWorld(rsWorld);
+			return;
+		}
+
+		queueQuickHopMessage(targetWorld.getId());
+		quickHopTargetWorld = rsWorld;
+		displaySwitcherAttempts = 0;
+	}
+
+	private void resetQuickHop()
+	{
+		displaySwitcherAttempts = 0;
+		quickHopTargetWorld = null;
+	}
+
+	private void queueConsoleMessage(final String message)
+	{
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.value(message)
+			.build());
+	}
+
+	private void queueQuickHopMessage(final int worldId)
+	{
+		final String chatMessage = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append("Quick-hopping to World ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(Integer.toString(worldId))
+			.append(ChatColorType.NORMAL)
+			.append("..")
+			.build();
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.runeLiteFormattedMessage(chatMessage)
+			.build());
+	}
+
+	private void queueFailedQuickHopMessage()
+	{
+		final String chatMessage = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append("Failed to quick-hop after ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(Integer.toString(displaySwitcherAttempts))
+			.append(ChatColorType.NORMAL)
+			.append(" attempts.")
+			.build();
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CONSOLE)
+			.runeLiteFormattedMessage(chatMessage)
+			.build());
+	}
+}

--- a/src/main/java/thestonedturtle/partypanel/ui/PlayerBanner.java
+++ b/src/main/java/thestonedturtle/partypanel/ui/PlayerBanner.java
@@ -37,6 +37,7 @@ import net.runelite.client.util.ImageUtil;
 import thestonedturtle.partypanel.data.PartyPlayer;
 
 import javax.swing.Box;
+import javax.swing.JButton;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -52,6 +53,7 @@ import java.awt.Insets;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.IntConsumer;
 
 public class PlayerBanner extends JPanel
 {
@@ -68,8 +70,12 @@ public class PlayerBanner extends JPanel
 	private final Map<String, JLabel> iconLabels = new HashMap<>();
 	@Getter
 	private final JLabel expandIcon = new JLabel();
+	private final JPanel worldPanel = new JPanel();
 	private final JLabel worldLabel = new JLabel();
 	private final JLabel spellbookIcon = new JLabel();
+	private final JButton hopToWorldButton = new JButton("Hop-to");
+	private boolean displayWorld;
+	private boolean showHopToWorldButton;
 
 	private final ImageIcon expandIconUp;
 	private final ImageIcon expandIconDown;
@@ -82,10 +88,13 @@ public class PlayerBanner extends JPanel
 	private BufferedImage currentHeart = null;
 	private boolean usingStamIcon;
 
-	public PlayerBanner(final PartyPlayer player, boolean expanded, boolean displayWorld, SpriteManager spriteManager)
+	public PlayerBanner(final PartyPlayer player, boolean expanded, boolean displayWorld,
+						boolean showHopToWorldButton, IntConsumer hopToWorld, SpriteManager spriteManager)
 	{
 		super();
 		this.player = player;
+		this.displayWorld = displayWorld;
+		this.showHopToWorldButton = showHopToWorldButton;
 
 		this.setLayout(new GridBagLayout());
 		this.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH - 14, 75));
@@ -107,8 +116,13 @@ public class PlayerBanner extends JPanel
 			expandIcon.setIcon(expandIconDown);
 		}
 
+		worldPanel.setLayout(new BorderLayout(4, 0));
+		worldPanel.setOpaque(false);
 		worldLabel.setHorizontalTextPosition(JLabel.LEFT);
-		worldLabel.setVisible(displayWorld);
+		worldPanel.add(worldLabel, BorderLayout.CENTER);
+		hopToWorldButton.setFocusable(false);
+		hopToWorldButton.addActionListener(e -> hopToWorld.accept(this.player.getWorld()));
+		worldPanel.add(hopToWorldButton, BorderLayout.EAST);
 
 		usingStamIcon = player.getStamina() > 0;
 		statsPanel.add(createIconPanel(spriteManager, SpriteID.Staticons.HITPOINTS, Skill.HITPOINTS.getName(), String.valueOf(player.getSkillBoostedLevel(Skill.HITPOINTS))));
@@ -181,17 +195,6 @@ public class PlayerBanner extends JPanel
 			usernameLabel.setText(player.getUsername() + levelText);
 		}
 
-		worldLabel.setText("Not logged in");
-		if (Strings.isNullOrEmpty(player.getUsername()))
-		{
-			worldLabel.setText("");
-		}
-		else if (player.getWorld() > 0)
-		{
-
-			worldLabel.setText("World " + player.getWorld());
-		}
-
 		final JPanel topRow = new JPanel(new BorderLayout());
 		topRow.setOpaque(false);
 		topRow.add(usernameLabel, BorderLayout.WEST);
@@ -199,7 +202,8 @@ public class PlayerBanner extends JPanel
 
 		final JPanel bottomRow = new JPanel(new BorderLayout());
 		bottomRow.setOpaque(false);
-		bottomRow.add(worldLabel, BorderLayout.WEST);
+		updateWorld(player.getWorld(), displayWorld, showHopToWorldButton);
+		bottomRow.add(worldPanel, BorderLayout.WEST);
 		bottomRow.add(spellbookIcon, BorderLayout.EAST);
 
 		nameContainer.add(topRow);
@@ -336,10 +340,17 @@ public class PlayerBanner extends JPanel
 		statsPanel.repaint();
 	}
 
-	public void updateWorld(int world, boolean displayWorlds)
+	public void updateWorld(final int world, final boolean displayWorlds, final boolean showHopToWorldButton)
 	{
-		worldLabel.setVisible(displayWorlds);
-		worldLabel.setText("World " + world);
+		this.displayWorld = displayWorlds;
+		this.showHopToWorldButton = showHopToWorldButton;
+
+		final boolean hasWorld = world > 0 && !Strings.isNullOrEmpty(player.getUsername());
+		final boolean displayWorld = this.displayWorld && hasWorld;
+		worldPanel.setVisible(displayWorld);
+		worldLabel.setText(hasWorld ? "World " + world : "");
+		hopToWorldButton.setVisible(displayWorld && this.showHopToWorldButton);
+		hopToWorldButton.setEnabled(hasWorld);
 	}
 
 	void updateSpellbookIcon(int spellbook, SpriteManager spriteManager)

--- a/src/main/java/thestonedturtle/partypanel/ui/PlayerBanner.java
+++ b/src/main/java/thestonedturtle/partypanel/ui/PlayerBanner.java
@@ -37,10 +37,12 @@ import net.runelite.client.util.ImageUtil;
 import thestonedturtle.partypanel.data.PartyPlayer;
 
 import javax.swing.Box;
-import javax.swing.JButton;
 import javax.swing.ImageIcon;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
@@ -73,9 +75,10 @@ public class PlayerBanner extends JPanel
 	private final JPanel worldPanel = new JPanel();
 	private final JLabel worldLabel = new JLabel();
 	private final JLabel spellbookIcon = new JLabel();
-	private final JButton hopToWorldButton = new JButton("Hop-to");
+	private final JPopupMenu hopToWorldPopupMenu = new JPopupMenu();
+	private final JMenuItem hopToWorldMenuItem = new JMenuItem();
 	private boolean displayWorld;
-	private boolean showHopToWorldButton;
+	private boolean showHopToWorldMenuOption;
 
 	private final ImageIcon expandIconUp;
 	private final ImageIcon expandIconDown;
@@ -89,12 +92,12 @@ public class PlayerBanner extends JPanel
 	private boolean usingStamIcon;
 
 	public PlayerBanner(final PartyPlayer player, boolean expanded, boolean displayWorld,
-						boolean showHopToWorldButton, IntConsumer hopToWorld, SpriteManager spriteManager)
+						boolean showHopToWorldMenuOption, IntConsumer hopToWorld, SpriteManager spriteManager)
 	{
 		super();
 		this.player = player;
 		this.displayWorld = displayWorld;
-		this.showHopToWorldButton = showHopToWorldButton;
+		this.showHopToWorldMenuOption = showHopToWorldMenuOption;
 
 		this.setLayout(new GridBagLayout());
 		this.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH - 14, 75));
@@ -104,6 +107,7 @@ public class PlayerBanner extends JPanel
 		statsPanel.setLayout(new GridLayout(0, 4));
 		statsPanel.setBorder(new EmptyBorder(5, 0, 0, 0));
 		statsPanel.setOpaque(true);
+		inheritBannerPopup(statsPanel);
 
 		expandIconDown = new ImageIcon(EXPAND_ICON);
 		expandIconUp = new ImageIcon(ImageUtil.rotateImage(EXPAND_ICON, Math.PI));
@@ -120,9 +124,8 @@ public class PlayerBanner extends JPanel
 		worldPanel.setOpaque(false);
 		worldLabel.setHorizontalTextPosition(JLabel.LEFT);
 		worldPanel.add(worldLabel, BorderLayout.CENTER);
-		hopToWorldButton.setFocusable(false);
-		hopToWorldButton.addActionListener(e -> hopToWorld.accept(this.player.getWorld()));
-		worldPanel.add(hopToWorldButton, BorderLayout.EAST);
+		hopToWorldMenuItem.addActionListener(e -> hopToWorld.accept(this.player.getWorld()));
+		hopToWorldPopupMenu.add(hopToWorldMenuItem);
 
 		usingStamIcon = player.getStamina() > 0;
 		statsPanel.add(createIconPanel(spriteManager, SpriteID.Staticons.HITPOINTS, Skill.HITPOINTS.getName(), String.valueOf(player.getSkillBoostedLevel(Skill.HITPOINTS))));
@@ -168,6 +171,7 @@ public class PlayerBanner extends JPanel
 		iconLabel.setPreferredSize(ICON_SIZE);
 		iconLabel.setMinimumSize(ICON_SIZE);
 		iconLabel.setOpaque(false);
+		inheritBannerPopup(iconLabel);
 
 		checkIcon = player.getMember().getAvatar() == null;
 		if (!checkIcon)
@@ -183,8 +187,10 @@ public class PlayerBanner extends JPanel
 		final JPanel nameContainer = new JPanel(new GridLayout(2, 1));
 		nameContainer.setBorder(new EmptyBorder(0, 5, 0, 0));
 		nameContainer.setOpaque(false);
+		inheritBannerPopup(nameContainer);
 
 		final JLabel usernameLabel = new JLabel();
+		inheritBannerPopup(usernameLabel);
 		if (Strings.isNullOrEmpty(player.getUsername()))
 		{
 			usernameLabel.setText("Not logged in");
@@ -197,12 +203,18 @@ public class PlayerBanner extends JPanel
 
 		final JPanel topRow = new JPanel(new BorderLayout());
 		topRow.setOpaque(false);
+		inheritBannerPopup(topRow);
 		topRow.add(usernameLabel, BorderLayout.WEST);
 		topRow.add(expandIcon, BorderLayout.EAST);
+		inheritBannerPopup(expandIcon);
 
 		final JPanel bottomRow = new JPanel(new BorderLayout());
 		bottomRow.setOpaque(false);
-		updateWorld(player.getWorld(), displayWorld, showHopToWorldButton);
+		inheritBannerPopup(bottomRow);
+		inheritBannerPopup(worldPanel);
+		inheritBannerPopup(worldLabel);
+		inheritBannerPopup(spellbookIcon);
+		updateWorld(player.getWorld(), displayWorld, showHopToWorldMenuOption);
 		bottomRow.add(worldPanel, BorderLayout.WEST);
 		bottomRow.add(spellbookIcon, BorderLayout.EAST);
 
@@ -231,6 +243,11 @@ public class PlayerBanner extends JPanel
 	{
 		final BufferedImage resized = ImageUtil.resizeImage(player.getMember().getAvatar(), Constants.ITEM_SPRITE_WIDTH - 4, Constants.ITEM_SPRITE_HEIGHT);
 		iconLabel.setIcon(new ImageIcon(resized));
+	}
+
+	private void inheritBannerPopup(final JComponent component)
+	{
+		component.setInheritsPopupMenu(true);
 	}
 
 	public void refreshStats()
@@ -272,6 +289,9 @@ public class PlayerBanner extends JPanel
 		panel.add(textLabel, BorderLayout.CENTER);
 		panel.setOpaque(false);
 		panel.setToolTipText(name);
+		inheritBannerPopup(panel);
+		inheritBannerPopup(iconLabel);
+		inheritBannerPopup(textLabel);
 
 		return panel;
 	}
@@ -340,17 +360,18 @@ public class PlayerBanner extends JPanel
 		statsPanel.repaint();
 	}
 
-	public void updateWorld(final int world, final boolean displayWorlds, final boolean showHopToWorldButton)
+	public void updateWorld(final int world, final boolean displayWorlds, final boolean showHopToWorldMenuOption)
 	{
 		this.displayWorld = displayWorlds;
-		this.showHopToWorldButton = showHopToWorldButton;
+		this.showHopToWorldMenuOption = showHopToWorldMenuOption;
 
 		final boolean hasWorld = world > 0 && !Strings.isNullOrEmpty(player.getUsername());
 		final boolean displayWorld = this.displayWorld && hasWorld;
 		worldPanel.setVisible(displayWorld);
 		worldLabel.setText(hasWorld ? "World " + world : "");
-		hopToWorldButton.setVisible(displayWorld && this.showHopToWorldButton);
-		hopToWorldButton.setEnabled(hasWorld);
+		hopToWorldMenuItem.setText(hasWorld ? "Hop-to World " + world : "Hop-to World");
+		hopToWorldMenuItem.setEnabled(displayWorld && this.showHopToWorldMenuOption);
+		setComponentPopupMenu(displayWorld && this.showHopToWorldMenuOption ? hopToWorldPopupMenu : null);
 	}
 
 	void updateSpellbookIcon(int spellbook, SpriteManager spriteManager)

--- a/src/main/java/thestonedturtle/partypanel/ui/PlayerBanner.java
+++ b/src/main/java/thestonedturtle/partypanel/ui/PlayerBanner.java
@@ -47,6 +47,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -75,7 +76,7 @@ public class PlayerBanner extends JPanel
 	private final JPanel worldPanel = new JPanel();
 	private final JLabel worldLabel = new JLabel();
 	private final JLabel spellbookIcon = new JLabel();
-	private final JPopupMenu hopToWorldPopupMenu = new JPopupMenu();
+	private final JPopupMenu hopToWorldPopupMenu = new CenteredPopupMenu();
 	private final JMenuItem hopToWorldMenuItem = new JMenuItem();
 	private boolean displayWorld;
 	private boolean showHopToWorldMenuOption;
@@ -248,6 +249,15 @@ public class PlayerBanner extends JPanel
 	private void inheritBannerPopup(final JComponent component)
 	{
 		component.setInheritsPopupMenu(true);
+	}
+
+	private static class CenteredPopupMenu extends JPopupMenu
+	{
+		@Override
+		public void show(final Component invoker, final int x, final int y)
+		{
+			super.show(invoker, x - getPreferredSize().width / 2, y);
+		}
 	}
 
 	public void refreshStats()

--- a/src/main/java/thestonedturtle/partypanel/ui/PlayerPanel.java
+++ b/src/main/java/thestonedturtle/partypanel/ui/PlayerPanel.java
@@ -110,7 +110,7 @@ public class PlayerPanel extends JPanel
 		this.itemManager = itemManager;
 		this.showInfo = config.autoExpandMembers();
 		this.banner = new PlayerBanner(selectedPlayer, showInfo, config.displayPlayerWorlds(),
-			config.showHopToWorldButton(), hopToWorld, spriteManager);
+			config.showHopToWorldMenuOption(), hopToWorld, spriteManager);
 		this.inventoryPanel = new PlayerInventoryPanel(selectedPlayer.getInventory(), selectedPlayer.getRunesInPouch(), itemManager);
 		this.equipmentPanel = new PlayerEquipmentPanel(selectedPlayer.getEquipment(), selectedPlayer.getQuiver(), spriteManager, itemManager);
 		this.skillsPanel = new PlayerSkillsPanel(selectedPlayer, config.displayVirtualLevels(), spriteManager);
@@ -367,6 +367,6 @@ public class PlayerPanel extends JPanel
 
 	public void updateWorld()
 	{
-		banner.updateWorld(player.getWorld(), config.displayPlayerWorlds(), config.showHopToWorldButton());
+		banner.updateWorld(player.getWorld(), config.displayPlayerWorlds(), config.showHopToWorldMenuOption());
 	}
 }

--- a/src/main/java/thestonedturtle/partypanel/ui/PlayerPanel.java
+++ b/src/main/java/thestonedturtle/partypanel/ui/PlayerPanel.java
@@ -64,6 +64,7 @@ import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.IntConsumer;
 
 @Getter
 public class PlayerPanel extends JPanel
@@ -100,7 +101,7 @@ public class PlayerPanel extends JPanel
 	private boolean showInfo;
 	private final Map<Integer, Boolean> tabMap = new HashMap<>();
 
-	public PlayerPanel(final PartyPlayer selectedPlayer, final PartyPanelConfig config,
+	public PlayerPanel(final PartyPlayer selectedPlayer, final PartyPanelConfig config, final IntConsumer hopToWorld,
 					   final SpriteManager spriteManager, final ItemManager itemManager)
 	{
 		this.player = selectedPlayer;
@@ -108,7 +109,8 @@ public class PlayerPanel extends JPanel
 		this.spriteManager = spriteManager;
 		this.itemManager = itemManager;
 		this.showInfo = config.autoExpandMembers();
-		this.banner = new PlayerBanner(selectedPlayer, showInfo, config.displayPlayerWorlds(), spriteManager);
+		this.banner = new PlayerBanner(selectedPlayer, showInfo, config.displayPlayerWorlds(),
+			config.showHopToWorldButton(), hopToWorld, spriteManager);
 		this.inventoryPanel = new PlayerInventoryPanel(selectedPlayer.getInventory(), selectedPlayer.getRunesInPouch(), itemManager);
 		this.equipmentPanel = new PlayerEquipmentPanel(selectedPlayer.getEquipment(), selectedPlayer.getQuiver(), spriteManager, itemManager);
 		this.skillsPanel = new PlayerSkillsPanel(selectedPlayer, config.displayVirtualLevels(), spriteManager);
@@ -363,8 +365,8 @@ public class PlayerPanel extends JPanel
 		skillsPanel.getTotalLevelPanel().updateTotalLevel(totalLevel);
 	}
 
-	public void updateDisplayPlayerWorlds()
+	public void updateWorld()
 	{
-		banner.updateWorld(player.getWorld(), config.displayPlayerWorlds());
+		banner.updateWorld(player.getWorld(), config.displayPlayerWorlds(), config.showHopToWorldButton());
 	}
 }


### PR DESCRIPTION
## What this feature does

It adds a `Hop-to` button to the party panel so you can quick-hop to party members from the sidebar. It also adds a config option to toggle the feature on or off.

 It looks like this:

<img width="321" height="214" alt="image" src="https://github.com/user-attachments/assets/b21d500c-458d-49fe-b3b6-f1212949711e" />

## Why? Doesn't RuneLite already have this?
Yes. RuneLite already has a similar feature in the World Hopper plugin: `Show hop-to menu option`. 

**But it sucks**:
When PKing, we often use the chat-channel to see each other’s worlds and hop to each other quickly. The problem is that the chat-channel is not always reliable; players can get kicked from it when hopping worlds (this is an Jagex issue), which makes RuneLite’s built-in quick-hop menu option unavailable.

This adds the same kind of quick-hop workflow to the party panel, where the party member world is already visible. It also makes hopping more direct than using an in-game submenu.

## What I added codewise

 - Added a `Show Hop-to World Button` config option.
 - The button only appears when `Display Player Worlds` is enabled.
 - Added a `Hop-to` button beside each visible party member world.
 - Added `WorldHopService` to handle the quick-hop flow separately from the main plugin class.
 - Matched RuneLite World Hopper’s quick-hop behavior:
   - resolves the target world through `WorldService`
   - creates a RuneLite world object
   - opens the world hopper
   - calls `client.hopToWorld(...)`
   - resets if the world switcher is busy
 - Added RuneLite-formatted console messages for quick-hop status.
 - Prevented hopping from a non-PvP world directly into a PvP world, matching RuneLite’s existing safety behavior.
